### PR TITLE
[DOC] Format all API pages according to the API template

### DIFF
--- a/_api-reference/analyze-apis.md
+++ b/_api-reference/analyze-apis.md
@@ -9,6 +9,8 @@ redirect_from:
 ---
 
 # Analyze API
+**Introduced 1.0**
+{: .label .label-purple }
 
 The Analyze API allows you to perform [text analysis]({{site.url}}{{site.baseurl}}/api-reference/analyze-apis/), which is the process of converting unstructured text into individual tokens (usually words) that are optimized for search.
 

--- a/_api-reference/cat/cat-aliases.md
+++ b/_api-reference/cat/cat-aliases.md
@@ -10,12 +10,12 @@ has_children: false
 ---
 
 # CAT aliases
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT aliases operation lists the mapping of aliases to indexes, plus routing and filtering information.
 
-## Example
+**Example**
 
 ```json
 GET _cat/aliases?v

--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -9,12 +9,12 @@ has_children: false
 ---
 
 # CAT allocation
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT allocation operation lists the allocation of disk space for indexes and the number of shards on each node.
 
-## Example
+**Example**
 
 ```json
 GET _cat/allocation?v

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -9,12 +9,12 @@ has_children: false
 ---
 
 # CAT cluster_manager
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT cluster manager operation lists information that helps identify the elected cluster manager node.
 
-## Example
+**Example**
 
 ```
 GET _cat/cluster_manager?v
@@ -36,6 +36,7 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 Parameter | Type | Description
 :--- | :--- | :---
 cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+
 ## Response
 
 ```json

--- a/_api-reference/cat/cat-count.md
+++ b/_api-reference/cat/cat-count.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT count
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT count operation lists the number of documents in your cluster.
 
-## Example
+**Example**
 
 ```json
 GET _cat/count?v

--- a/_api-reference/cat/cat-field-data.md
+++ b/_api-reference/cat/cat-field-data.md
@@ -9,12 +9,12 @@ redirect_from:
 ---
 
 # CAT fielddata
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT fielddata operation lists the memory size used by each field per node.
 
-## Example
+**Example**
 
 ```json
 GET _cat/fielddata?v

--- a/_api-reference/cat/cat-health.md
+++ b/_api-reference/cat/cat-health.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT health
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT health operation lists the status of the cluster, how long the cluster has been up, the number of nodes, and other useful information that helps you analyze the health of your cluster.
 
-## Example
+**Example**
 
 ```json
 GET _cat/health?v

--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -9,12 +9,12 @@ redirect_from:
 ---
 
 # CAT indices
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT indices operation lists information related to indexes, that is, how much disk space they are using, how many shards they have, their health status, and so on.
 
-## Example
+**Example**
 
 ```
 GET _cat/indices?v

--- a/_api-reference/cat/cat-nodeattrs.md
+++ b/_api-reference/cat/cat-nodeattrs.md
@@ -9,12 +9,12 @@ redirect_from:
 ---
 
 # CAT nodeattrs
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT nodeattrs operation lists the attributes of custom nodes.
 
-## Example
+**Example**
 
 ```
 GET _cat/nodeattrs?v

--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -10,14 +10,14 @@ redirect_from:
 ---
 
 # CAT nodes
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT nodes operation lists node-level information, including node roles and load metrics.
 
 A few important node metrics are `pid`, `name`, `cluster_manager`, `ip`, `port`, `version`, `build`, `jdk`, along with `disk`, `heap`, `ram`, and `file_desc`.
 
-## Example
+**Example**
 
 ```
 GET _cat/nodes?v

--- a/_api-reference/cat/cat-pending-tasks.md
+++ b/_api-reference/cat/cat-pending-tasks.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT pending tasks
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT pending tasks operation lists the progress of all pending tasks, including task priority and time in queue.
 
-## Example
+**Example**
 
 ```
 GET _cat/pending_tasks?v

--- a/_api-reference/cat/cat-plugins.md
+++ b/_api-reference/cat/cat-plugins.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT plugins
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT plugins operation lists the names, components, and versions of the installed plugins.
 
-## Example
+**Example**
 
 ```
 GET _cat/plugins?v

--- a/_api-reference/cat/cat-recovery.md
+++ b/_api-reference/cat/cat-recovery.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT recovery
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT recovery operation lists all completed and ongoing index and shard recoveries.
 
-## Example
+**Example**
 
 ```
 GET _cat/recovery?v

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT repositories
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT repositories operation lists all completed and ongoing index and shard recoveries.
 
-## Example
+**Example**
 
 ```
 GET _cat/repositories?v

--- a/_api-reference/cat/cat-segment-replication.md
+++ b/_api-reference/cat/cat-segment-replication.md
@@ -7,7 +7,7 @@ has_children: false
 ---
 
 # CAT segment replication
-Introduced 2.7
+**Introduced 2.7**
 {: .label .label-purple }
 
 The CAT segment replication operation returns information about active and last completed [segment replication]({{site.url}}{{site.baseurl}}/opensearch/segment-replication/index) events on each replica shard, including related shard-level metrics. These metrics provide information about how far behind the primary shard the replicas are lagging.
@@ -47,7 +47,7 @@ Parameter | Data type  | Description
 `v` | Boolean    | If `true`, the response includes column headings. Defaults to `false`.
 `s` | String     | Specifies to sort the results. For example, `s=shardId:desc` sorts by shardId in descending order.
 
-## Examples 
+### Examples 
 
 The following examples illustrate various segment replication responses.
 

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT segments
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The cat segments operation lists Lucene segment-level information for each index.
 
-## Example
+**Example**
 
 ```
 GET _cat/segments?v

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT shards
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT shards operation lists the state of all primary and replica shards and how they are distributed.
 
-## Example
+**Example**
 
 ```
 GET _cat/shards?v

--- a/_api-reference/cat/cat-snapshots.md
+++ b/_api-reference/cat/cat-snapshots.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT snapshots
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT snapshots operation lists all snapshots for a repository.
 
-## Example
+**Example**
 
 ```
 GET _cat/snapshots?v

--- a/_api-reference/cat/cat-tasks.md
+++ b/_api-reference/cat/cat-tasks.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # CAT tasks
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The CAT tasks operation lists the progress of all tasks currently running on your cluster.
 
-## Example
+**Example**
 
 ```
 GET _cat/tasks?v

--- a/_api-reference/cluster-api/cluster-allocation.md
+++ b/_api-reference/cluster-api/cluster-allocation.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 # Cluster allocation explain
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The most basic cluster allocation explain request finds an unassigned shard and explains why it can't be allocated to a node.
@@ -17,7 +17,7 @@ The most basic cluster allocation explain request finds an unassigned shard and 
 If you add some options, you can instead get information on a specific shard, including why OpenSearch assigned it to its current node.
 
 
-## Example
+**Example**
 
 ```json
 GET _cluster/allocation/explain?include_yes_decisions=true

--- a/_api-reference/cluster-api/cluster-awareness.md
+++ b/_api-reference/cluster-api/cluster-awareness.md
@@ -10,6 +10,8 @@ redirect_from:
 ---
 
 # Cluster routing and awareness
+**Introduced 1.0**
+{: .label .label-purple }
 
 To control the distribution of search or HTTP traffic, you can use the weights per awareness attribute to control the distribution of search or HTTP traffic across zones. This is commonly used for zonal deployments, heterogeneous instances, and routing traffic away from zones during zonal failure.
 
@@ -49,11 +51,11 @@ In the following example request body, `zone_1` and `zone_2` receive 50 requests
 }
 ```
 
-## Example: Weighted round robin search
+#### Example: Weighted round robin search
 
 The following example request creates a round robin shard allocation for search traffic by using an undefined ratio:
 
-### Request
+#### Request
 
 ```json
 PUT /_cluster/routing/awareness/zone/weights
@@ -69,7 +71,7 @@ PUT /_cluster/routing/awareness/zone/weights
 ```
 {% include copy-curl.html %}
 
-### Response
+#### Response
 
 ```
 {
@@ -78,18 +80,18 @@ PUT /_cluster/routing/awareness/zone/weights
 ```
 
 
-## Example: Getting weights for all zones
+#### Example: Getting weights for all zones
 
 The following example request gets weights for all zones.
 
-### Request
+#### Request
 
 ```json
 GET /_cluster/routing/awareness/zone/weights
 ```
 {% include copy-curl.html %}
 
-### Response
+#### Response
 
 OpenSearch responds with the weight of each zone:
 
@@ -106,18 +108,18 @@ OpenSearch responds with the weight of each zone:
 }
 ```
 
-## Example: Deleting weights
+#### Example: Deleting weights
 
 You can remove your weight ratio for each zone using the `DELETE` method.
 
-### Request
+#### Request
 
 ```json
 DELETE /_cluster/routing/awareness/zone/weights
 ```
 {% include copy-curl.html %}
 
-### Response
+#### Response
 
 ```json
 {

--- a/_api-reference/cluster-api/cluster-decommission.md
+++ b/_api-reference/cluster-api/cluster-decommission.md
@@ -10,6 +10,8 @@ redirect_from:
 ---
 
 # Cluster decommission
+**Introduced 1.0**
+{: .label .label-purple }
 
 The cluster decommission operation adds support decommissioning based on awareness. It greatly benefits multi-zone deployments, where awareness attributes, such as `zones`, can aid in applying new upgrades to a cluster in a controlled fashion. This is especially useful during outages, in which case, you can decommission the unhealthy zone to prevent replication requests from stalling and prevent your request backlog from becoming too large.
 
@@ -32,11 +34,11 @@ awareness_attribute_name | String | The name of awareness attribute, usually `zo
 awareness_attribute_value | String | The value of the awareness attribute. For example, if you have shards allocated in two different zones, you can give each zone a value of `zone-a` or `zoneb`. The cluster decommission operation decommissions the zone listed in the method.
 
 
-## Example: Decommissioning and recommissioning a zone
+#### Example: Decommissioning and recommissioning a zone
 
 You can use the following example requests to decommission and recommission a zone:
 
-### Request
+#### Request
 
 The following example request decommissions `zone-a`:
 
@@ -52,7 +54,7 @@ DELETE /_cluster/decommission/awareness
 ```
 {% include copy-curl.html %}
 
-### Response
+#### Response
 
 
 ```json
@@ -61,18 +63,18 @@ DELETE /_cluster/decommission/awareness
 }
 ```
 
-## Example: Getting zone decommission status
+#### Example: Getting zone decommission status
 
 The following example requests returns the decommission status of all zones.
 
-### Request
+#### Request
 
 ```json
 GET /_cluster/decommission/awareness/zone/_status
 ```
 {% include copy-curl.html %}
 
-### Response
+#### Response
 
 ```json
 {

--- a/_api-reference/cluster-api/cluster-health.md
+++ b/_api-reference/cluster-api/cluster-health.md
@@ -10,14 +10,14 @@ redirect_from:
 ---
 
 # Cluster health
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The most basic cluster health request returns a simple status of the health of your cluster. OpenSearch expresses cluster health in three colors: green, yellow, and red. A green status means all primary shards and their replicas are allocated to nodes. A yellow status means all primary shards are allocated to nodes, but some replicas aren't. A red status means at least one primary shard is not allocated to any node.
 
 To get the status of a specific index, provide the index name.
 
-## Example
+**Example**
 
 This request waits 50 seconds for the cluster to reach the yellow status or better:
 

--- a/_api-reference/cluster-api/cluster-settings.md
+++ b/_api-reference/cluster-api/cluster-settings.md
@@ -9,19 +9,19 @@ redirect_from:
 ---
 
 # Cluster settings
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The cluster settings operation lets you check the current settings for your cluster, review default settings, and change settings. When you update a setting using the API, OpenSearch applies it to all nodes in the cluster.
 
-### Path and HTTP methods
+## Path and HTTP methods
 
 ```
 GET _cluster/settings
 PUT _cluster/settings
 ```
 
-### Path parameters
+## Path parameters
 
 All cluster setting parameters are optional.
 
@@ -51,7 +51,7 @@ PUT _cluster/settings
 }
 ```
 
-### Request fields
+## Request fields
 
 The GET operation has no request body options. All cluster setting field parameters are optional.
 

--- a/_api-reference/cluster-api/cluster-stats.md
+++ b/_api-reference/cluster-api/cluster-stats.md
@@ -10,12 +10,12 @@ redirect_from:
 ---
 
 # Cluster stats
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The cluster stats API operation returns statistics about your cluster.
 
-## Examples
+**Examples**
 
 ```json
 GET _cluster/stats/nodes/_cluster_manager
@@ -28,7 +28,6 @@ GET _cluster/stats/nodes/_cluster_manager
 GET _cluster/stats
 GET _cluster/stats/nodes/<node-filters>
 ```
-
 
 ## URL parameters
 

--- a/_api-reference/cluster-api/index.md
+++ b/_api-reference/cluster-api/index.md
@@ -8,5 +8,7 @@ redirect_from:
 ---
 
 # Cluster APIs
+**Introduced 1.0**
+{: .label .label-purple }|
 
 The cluster APIs allow you to manage your cluster. You can use them to check cluster health, modify settings, retrieve statistics, and more.

--- a/_api-reference/common-parameters.md
+++ b/_api-reference/common-parameters.md
@@ -7,6 +7,8 @@ redirect_from:
 ---
 
 # Common REST parameters
+**Introduced 1.0**
+{: .label .label-purple }
 
 OpenSearch supports the following parameters for all REST operations:
 
@@ -14,7 +16,7 @@ OpenSearch supports the following parameters for all REST operations:
 
 To convert output units to human-readable values (for example, `1h` for 1 hour and `1kb` for 1,024 bytes), add `?human=true` to the request URL.  
 
-### Example request
+#### Example request
 
 The following request requires response values to be in human-readable format:
 
@@ -27,7 +29,7 @@ GET <index_name>/_search?human=true
 
 To get back JSON responses in a readable format, add `?pretty=true` to the request URL.  
 
-### Example request
+#### Example request
 
 The following request requires the response to be displayed in pretty JSON format:
 
@@ -40,7 +42,7 @@ GET <index_name>/_search?pretty=true
 
 To specify the type of content in the request body, use the `Content-Type` key name in the request header. Most operations support JSON, YAML, and CBOR formats.  
 
-### Example request
+#### Example request
 
 The following request specifies JSON format for the request body:
 
@@ -54,7 +56,7 @@ curl -H "Content-type: application/json" -XGET localhost:9200/_scripts/<template
 If the client library does not accept a request body for non-POST requests, use the `source` query string parameter to pass the request body. Also, specify the `source_content_type` parameter with a supported media type such as `application/json`.  
 
 
-### Example request
+#### Example request
 
 The following request searches the documents in the `shakespeare` index for a specific field and value:
 
@@ -67,7 +69,7 @@ GET shakespeare/search?source={"query":{"exists":{"field":"speaker"}}}&source_co
 
 To include the error stack trace in the response when an exception is raised, add `error_trace=true` to the request URL.  
 
-### Example request
+#### Example request
 
 The following request sets `error_trace` to `true` so that the response returns exception-triggered errors:
 
@@ -80,7 +82,7 @@ GET <index_name>/_search?error_trace=true
 
 To reduce the response size use the `filter_path` parameter to filter the fields that are returned. This parameter takes a comma-separated list of filters. It supports using wildcards to match any field or part of a field's name. You can also exclude fields with `-`.  
 
-### Example request
+#### Example request
 
 The following request specifies filters to limit the fields returned in the response:
 

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -7,14 +7,13 @@ redirect_from:
 ---
 
 # Count
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The count API gives you quick access to the number of documents that match a query.
 You can also use it to check the document count of an index, data stream, or cluster.
 
-
-## Example
+**Example**
 
 To see the number of documents that match a query:
 

--- a/_api-reference/document-apis/bulk.md
+++ b/_api-reference/document-apis/bulk.md
@@ -8,7 +8,7 @@ redirect_from:
 ---
 
 # Bulk
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The bulk operation lets you add, update, or delete multiple documents in a single request. Compared to individual OpenSearch indexing requests, the bulk operation has significant performance benefits. Whenever practical, we recommend batching indexing operations into bulk requests.
@@ -17,7 +17,7 @@ The bulk operation lets you add, update, or delete multiple documents in a singl
 Beginning in OpenSearch 2.9, when indexing documents using the bulk operation, the document `_id` must be 512 bytes or less in size.
 {: .note}
 
-## Example
+**Example**
 
 ```json
 POST _bulk

--- a/_api-reference/document-apis/delete-by-query.md
+++ b/_api-reference/document-apis/delete-by-query.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Delete by query
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple}
 
 You can include a query as part of your delete request so OpenSearch deletes all documents that match that query.
 
-## Example
+**Example**
 
 ```json
 POST sample-index1/_delete_by_query

--- a/_api-reference/document-apis/delete-document.md
+++ b/_api-reference/document-apis/delete-document.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Delete document
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 If you no longer need a document in your index, you can use the delete document API operation to delete it.
 
-## Example
+**Example**
 
 ```
 DELETE /sample-index1/_doc/1

--- a/_api-reference/document-apis/get-documents.md
+++ b/_api-reference/document-apis/get-documents.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Get document
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 After adding a JSON document to your index, you can use the get document API operation to retrieve the document's information and data.
 
-## Example
+**Example**
 
 ```json
 GET sample-index1/_doc/1

--- a/_api-reference/document-apis/index-document.md
+++ b/_api-reference/document-apis/index-document.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Index document
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple}
 
 Before you can search for data, you must first add documents. This operation adds a single document to your index.
 
-## Example
+**Example**
 
 ```json
 PUT sample-index/_doc/1

--- a/_api-reference/document-apis/index.md
+++ b/_api-reference/document-apis/index.md
@@ -8,6 +8,8 @@ redirect_from:
 ---
 
 # Document APIs
+**Introduced 1.0**
+{: .label .label-purple }
 
 The document APIs allow you to handle documents relative to your index, such as adding, updating, and deleting documents.
 

--- a/_api-reference/document-apis/multi-get.md
+++ b/_api-reference/document-apis/multi-get.md
@@ -8,7 +8,7 @@ redirect_from:
 ---
 
 # Multi-get documents
-Introduced 1.0 
+**Introduced 1.0**
 {: .label .label-purple }
 
 The multi-get operation allows you to run multiple GET operations in one request, so you can get back all documents that match your criteria.

--- a/_api-reference/document-apis/reindex.md
+++ b/_api-reference/document-apis/reindex.md
@@ -9,12 +9,12 @@ redirect_from:
 ---
 
 # Reindex document
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple}
 
 The reindex document API operation lets you copy all or a subset of your data from a source index into a destination index.
 
-## Example
+**Example**
 
 ```json
 POST /_reindex

--- a/_api-reference/document-apis/update-by-query.md
+++ b/_api-reference/document-apis/update-by-query.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Update by query
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple}
 
 You can include a query and a script as part of your update request so OpenSearch can run the script to update all of the documents that match the query.
 
-## Example
+**Example**
 
 ```json
 POST test-index1/_update_by_query

--- a/_api-reference/document-apis/update-document.md
+++ b/_api-reference/document-apis/update-document.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Update document
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 If you need to update a document's fields in your index, you can use the update document API operation. You can do so by specifying the new data you want in your index or by including a script in your request body, which OpenSearch runs to update the document.
 
-## Example
+**Example**
 
 ```json
 POST /sample-index1/_update/1

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 # Explain
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Wondering why a specific document ranks higher (or lower) for a query? You can use the explain API for an explanation of how the relevance score (`_score`) is calculated for every result.
@@ -18,7 +18,7 @@ The explain API is an expensive operation in terms of both resources and time. O
 {: .warning }
 
 
-## Example
+**Example**
 
 To see the explain output for all results, set the `explain` flag to `true` either in the URL or in the body of the request:
 

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -9,13 +9,13 @@ redirect_from:
 ---
 
 # Alias
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 An alias is a virtual pointer that you can use to reference one or more indexes. Creating and updating aliases are atomic operations, so you can reindex your data and point an alias at it without any downtime.
 
 
-## Example
+**Example**
 
 ```json
 POST _aliases

--- a/_api-reference/index-apis/clear-index-cache.md
+++ b/_api-reference/index-apis/clear-index-cache.md
@@ -6,6 +6,8 @@ nav_order: 10
 ---
 
 # Clear cache
+**Introduced 1.0**
+{: .label .label-purple }
 
 The clear cache API operation clears the caches of one or more indexes. For data streams, the API clears the caches of the stream’s backing indexes.
 
@@ -36,11 +38,11 @@ All query parameters are optional.
 | query | Boolean | If `true`, clears the query cache. Defaults to `true`. |
 | request | Boolean | If `true`, clears the request cache. Defaults to `true`. |
 
-## Example requests
+#### Example requests
 
 The following example requests show multiple clear cache API uses.
 
-### Clear a specific cache
+##### Clear a specific cache
 
 The following request clears the fields cache only:
 
@@ -67,7 +69,7 @@ POST /my-index/_cache/clear?request=true
 ```
 {% include copy-curl.html %}
 
-### Clear the cache for specific fields
+#### Clear the cache for specific fields
 
 The following request clears the fields caches of `fielda` and `fieldb`:
 
@@ -76,7 +78,7 @@ POST /my-index/_cache/clear?fields=fielda,fieldb
 ```
 {% include copy-curl.html %}
 
-### Clear caches for specific data streams or indexes
+#### Clear caches for specific data streams or indexes
 
 The following request clears the cache for two specific indexes:
 
@@ -85,7 +87,7 @@ POST /my-index,my-index2/_cache/clear
 ```
 {% include copy-curl.html %}
 
-### Clear caches for all data streams and indexes
+#### Clear caches for all data streams and indexes
 
 The following request clears the cache for all data streams and indexes:
 
@@ -94,7 +96,7 @@ POST /_cache/clear
 ```
 {% include copy-curl.html %}
 
-### Clear unused entries from the cache on search-capable nodes
+#### Clear unused entries from the cache on search-capable nodes
 
 ```json
 POST /*/_cache/clear?file=true 
@@ -115,7 +117,7 @@ The `POST /books,hockey/_cache/clear` request returns the following fields:
 }
 ```
 
-#### Response fields
+## Response fields
 
 The `POST /books,hockey/_cache/clear` request returns the following response fields:
 

--- a/_api-reference/index-apis/clone.md
+++ b/_api-reference/index-apis/clone.md
@@ -8,10 +8,12 @@ redirect_from:
 ---
 
 # Clone index
+**Introduced 1.0**
+{: .label .label-purple }
 
 The clone index API operation clones all data in an existing read-only index into a new index. The new index cannot already exist.
 
-## Example
+**Example**
 
 ```json
 PUT /sample-index1/_clone/cloned-index1

--- a/_api-reference/index-apis/close-index.md
+++ b/_api-reference/index-apis/close-index.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Close index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The close index API operation closes an index. Once an index is closed, you cannot add data to it or search for any data within the index.
 
-## Example
+**Example**
 
 ```json
 POST /sample-index/_close

--- a/_api-reference/index-apis/create-index.md
+++ b/_api-reference/index-apis/create-index.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 # Create index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 While you can create an index by using a document as a base, you can also create an empty index for later use.

--- a/_api-reference/index-apis/dangling-index.md
+++ b/_api-reference/index-apis/dangling-index.md
@@ -6,6 +6,8 @@ nav_order: 30
 ---
 
 # Dangling indexes API
+**Introduced 1.0**
+{: .label .label-purple }
 
 After a node joins a cluster, dangling indexes occur if any shards exist in the node's local directory that do not already exist in the cluster. Dangling indexes can be listed, deleted, or imported.
 
@@ -47,7 +49,7 @@ accept_data_loss | Boolean | Must be set to `true` for an `import` or `delete` b
 timeout | Time units | The amount of time to wait for a response. If no response is received in the defined time period, an error is returned. Default is `30` seconds.
 cluster_manager_timeout | Time units | The amount of time to wait for a connection to the cluster manager. If no response is received in the defined time period, an error is returned. Default is `30` seconds.
 
-## Examples
+#### Examples
 
 The following are example requests and a example response.
 

--- a/_api-reference/index-apis/delete-index.md
+++ b/_api-reference/index-apis/delete-index.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Delete index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 If you no longer need an index, you can use the delete index API operation to delete it.
 
-## Example
+**Example**
 
 ```json
 DELETE /sample-index

--- a/_api-reference/index-apis/exists.md
+++ b/_api-reference/index-apis/exists.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Index exists
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The index exists API operation returns whether or not an index already exists.
 
-## Example
+**Example**
 
 ```json
 HEAD /sample-index

--- a/_api-reference/index-apis/get-index.md
+++ b/_api-reference/index-apis/get-index.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Get index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 You can use the get index API operation to return information about an index.
 
-## Example
+**Example**
 
 ```json
 GET /sample-index

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Get settings
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The get settings API operation returns all the settings in your index.
 
-## Example
+**Example**
 
 ```json
 GET /sample-index1/_settings

--- a/_api-reference/index-apis/index.md
+++ b/_api-reference/index-apis/index.md
@@ -8,6 +8,8 @@ redirect_from:
 ---
 
 # Index APIs
+**Introduced 1.0**
+{: .label .label-purple }
 
 The index API operations let you interact with indexes in your cluster. Using these operations, you can create, delete, close, and complete other index-related operations.
 

--- a/_api-reference/index-apis/open-index.md
+++ b/_api-reference/index-apis/open-index.md
@@ -8,12 +8,12 @@ redirect_from:
 ---
 
 # Open index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The open index API operation opens a closed index, letting you add or search for data within the index.
 
-## Example
+**Example**
 
 ```json
 POST /sample-index/_open

--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 # Create or update mappings
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 If you want to create or add mappings and fields to an index, you can use the put mapping API operation. For an existing mapping, this operation updates the mapping.
@@ -43,9 +43,9 @@ The request body must contain `properties`, which has all of the mappings that y
 }
 ```
 
-## Optional request body fields
+#### Optional request body fields
 
-### dynamic
+#### dynamic
 
 You can make the document structure match the structure of the index mapping by setting the `dynamic` request body field to `strict`, as seen in the following example:
 
@@ -60,7 +60,7 @@ You can make the document structure match the structure of the index mapping by 
 }
 ```
 
-## Optional query parameters
+#### Optional query parameters
 
 Optionally, you can add query parameters to make a more specific request. For example, to skip any missing or closed indexes in the response, you can add the `ignore_unavailable` query parameter to your request as follows:
 

--- a/_api-reference/index-apis/shrink-index.md
+++ b/_api-reference/index-apis/shrink-index.md
@@ -8,10 +8,12 @@ redirect_from:
 ---
 
 # Shrink index
+**Introduced 1.0**
+{: .label .label-purple }
 
 The shrink index API operation moves all of your data in an existing index into a new index with fewer primary shards.
 
-## Example
+**Example**
 
 ```json
 POST /my-old-index/_shrink/my-new-index
@@ -66,7 +68,7 @@ alias | Object | Sets an alias for the target index. Can have the fields `filter
 settings | Object | Index settings you can apply to your target index. See [Index Settings]({{site.url}}{{site.baseurl}}/im-plugin/index-settings/).
 [max_shard_size](#the-max_shard_size-parameter) | Bytes | Specifies the maximum size of a primary shard in the target index. Because `max_shard_size` conflicts with the `index.number_of_shards` setting, you cannot set both of them at the same time. 
 
-### The `max_shard_size` parameter
+#### The `max_shard_size` parameter
 
 The `max_shard_size` parameter specifies the maximum size of a primary shard in the target index. OpenSearch uses `max_shard_size` and the total storage for all primary shards in the source index to calculate the number of primary shards and their size for the target index. 
 
@@ -80,6 +82,6 @@ The maximum number of primary shards for the target index is equal to the number
 The minimum number of primary shards for the target index is 1.
 {: .note}
 
-## Index codec considerations
+#### Index codec considerations
 
 For index codec considerations, see [Index codecs]({{site.url}}{{site.baseurl}}/im-plugin/index-codecs/#splits-and-shrinks).

--- a/_api-reference/index-apis/split.md
+++ b/_api-reference/index-apis/split.md
@@ -8,10 +8,12 @@ redirect_from:
 ---
 
 # Split index
+**Introduced 1.0**
+{: .label .label-purple }
 
 The split index API operation splits an existing read-only index into a new index, cutting each primary shard into some amount of primary shards in the new index.
 
-## Example
+**Example**
 
 ```json
 PUT /sample-index1/_split/split-index1
@@ -74,6 +76,6 @@ The split index API operation creates a new target index, so you can specify any
 }
 ```
 
-## Index codec considerations
+#### Index codec considerations
 
 For index codec considerations, see [Index codecs]({{site.url}}{{site.baseurl}}/im-plugin/index-codecs/#splits-and-shrinks).

--- a/_api-reference/index-apis/stats.md
+++ b/_api-reference/index-apis/stats.md
@@ -6,6 +6,8 @@ nav_order: 72
 ---
 
 # Index Stats 
+**Introduced 1.0**
+{: .label .label-purple }
 
 The Index Stats API provides index statistics. For data streams, the API provides statistics for the stream's backing indexes. By default, the returned statistics are index level. To receive shard-level statistics, set the `level` parameter to `shards`.
 

--- a/_api-reference/index-apis/update-settings.md
+++ b/_api-reference/index-apis/update-settings.md
@@ -8,14 +8,14 @@ redirect_from:
 ---
 
 # Update settings
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 You can use the update settings API operation to update index-level settings. You can change dynamic index settings at any time, but static settings cannot be changed after index creation. For more information about static and dynamic index settings, see [Create index]({{site.url}}{{site.baseurl}}/api-reference/index-apis/create-index/).
 
 Aside from the static and dynamic index settings, you can also update individual plugins' settings. To get the full list of updatable settings, run `GET <target-index>/_settings?include_defaults=true`.
 
-## Example
+**Example**
 
 ```json
 PUT /sample-index1/_settings

--- a/_api-reference/index.md
+++ b/_api-reference/index.md
@@ -10,6 +10,8 @@ redirect_from:
 ---
 
 # REST API reference
+**Introduced 1.0**
+{: .label .label-purple }
 
 You can use REST APIs for most operations in OpenSearch. In this reference, we provide a description of the API, and details that include the paths and HTTP methods, supported parameters, and example requests and responses.
 

--- a/_api-reference/ingest-apis/create-ingest.md
+++ b/_api-reference/ingest-apis/create-ingest.md
@@ -9,6 +9,8 @@ redirect_from:
 ---
 
 # Create pipeline
+**Introduced 1.0**
+{: .label .label-purple }
 
 Use the create pipeline API operation to create or update pipelines in OpenSearch. Note that the pipeline requires you to define at least one processor that specifies how to change the documents. 
 

--- a/_api-reference/ingest-apis/delete-ingest.md
+++ b/_api-reference/ingest-apis/delete-ingest.md
@@ -9,6 +9,8 @@ redirect_from:
 ---
 
 # Delete pipeline
+**Introduced 1.0**
+{: .label .label-purple }
 
 Use the following request to delete a pipeline. 
 

--- a/_api-reference/ingest-apis/get-ingest.md
+++ b/_api-reference/ingest-apis/get-ingest.md
@@ -9,6 +9,8 @@ redirect_from:
 ---
 
 # Get pipeline
+**Introduced 1.0**
+{: .label .label-purple }
 
 Use the get ingest pipeline API operation to retrieve all the information about the pipeline.
 

--- a/_api-reference/ingest-apis/index.md
+++ b/_api-reference/ingest-apis/index.md
@@ -8,6 +8,8 @@ redirect_from:
 ---
 
 # Ingest APIs
+**Introduced 1.0**
+{: .label .label-purple }
 
 Ingest APIs are a valuable tool for loading data into a system. Ingest APIs work together with [ingest pipelines]({{site.url}}{{site.baseurl}}/api-reference/ingest-apis/ingest-pipelines/) and [ingest processors]({{site.url}}{{site.baseurl}}/api-reference/ingest-apis/ingest-processors/) to process or transform data from a variety of sources and in a variety of formats. 
 

--- a/_api-reference/ingest-apis/ingest-pipelines.md
+++ b/_api-reference/ingest-apis/ingest-pipelines.md
@@ -7,6 +7,8 @@ nav_order: 5
 ---
 
 # Ingest pipelines
+**Introduced 1.0**
+{: .label .label-purple }
 
 An _ingest pipeline_ is a sequence of _processors_ that are applied to documents as they are ingested into an index. Each [processor]({{site.url}}{{site.baseurl}}/api-reference/ingest-apis/ingest-processors/) in a pipeline performs a specific task, such as filtering, transforming, or enriching data. 
 
@@ -33,7 +35,7 @@ A _pipeline definition_ describes the sequence of an ingest pipeline and can be 
 }
 ```
 
-### Request body fields
+#### Request body fields
 
 Field | Required | Type | Description
 :--- | :--- | :--- | :---

--- a/_api-reference/ingest-apis/ingest-processors.md
+++ b/_api-reference/ingest-apis/ingest-processors.md
@@ -7,6 +7,8 @@ has_children: true
 ---
 
 # Ingest processors
+**Introduced 1.0**
+{: .label .label-purple }
 
 Ingest processors are a core component of [ingest pipelines]({{site.url}}{{site.baseurl}}/api-reference/ingest-apis/ingest-pipelines/) because they preprocess documents before indexing. For example, you can remove fields, extract values from text, convert data formats, or append additional information.
 

--- a/_api-reference/ingest-apis/pipeline-failures.md
+++ b/_api-reference/ingest-apis/pipeline-failures.md
@@ -7,6 +7,8 @@ nav_order: 15
 ---
 
 # Handling pipeline failures
+**Introduced 1.0**
+{: .label .label-purple }
 
 Each ingest pipeline consists of a series of processors that are applied to the documents in sequence. If a processor fails, the entire pipeline will fail. You have two options for handling failures:
 

--- a/_api-reference/ingest-apis/processors/append.md
+++ b/_api-reference/ingest-apis/processors/append.md
@@ -7,6 +7,8 @@ nav_order: 10
 ---
 
 # Append
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `append` processor is used to add values to a field:
 - If the field is an array, the `append` processor appends the specified values to that array.

--- a/_api-reference/ingest-apis/processors/bytes.md
+++ b/_api-reference/ingest-apis/processors/bytes.md
@@ -7,6 +7,8 @@ nav_order: 20
 ---
 
 # Bytes
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `bytes` processor converts a human-readable byte value to its equivalent value in bytes. The field can be a scalar or an array. If the field is a scalar, the value is converted and stored in the field. If the field is an array, all values of the array are converted.
 

--- a/_api-reference/ingest-apis/processors/convert.md
+++ b/_api-reference/ingest-apis/processors/convert.md
@@ -7,6 +7,8 @@ nav_order: 30
 ---
 
 # Convert
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `convert` processor converts a field in a document to a different type, for example, a string to an integer or an integer to a string. For an array field, all values in the array are converted. The following is the syntax for the `convert` processor: 
 

--- a/_api-reference/ingest-apis/processors/csv.md
+++ b/_api-reference/ingest-apis/processors/csv.md
@@ -7,6 +7,8 @@ nav_order: 40
 ---
 
 # CSV
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `csv` processor is used to parse CSVs and store them as individual fields in a document. The processor ignores empty fields. The following is the syntax for the `csv` processor: 
 

--- a/_api-reference/ingest-apis/processors/date.md
+++ b/_api-reference/ingest-apis/processors/date.md
@@ -7,6 +7,8 @@ nav_order: 50
 ---
 
 # Date
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `date` processor is used to parse dates from document fields and to add the parsed data to a new field. By default, the parsed data is stored in the `@timestamp` field. The following is the syntax for the `date` processor:
 

--- a/_api-reference/ingest-apis/processors/ip2geo.md
+++ b/_api-reference/ingest-apis/processors/ip2geo.md
@@ -7,7 +7,7 @@ nav_order: 130
 ---
 
 # IP2Geo
-Introduced 2.10
+**Introduced 2.10**
 {: .label .label-purple }
 
 The `ip2geo` processor adds information about the geographical location of an IPv4 or IPv6 address. The `ip2geo` processor uses IP geolocation (GeoIP) data from an external endpoint and therefore requires an additional component, `datasource`, that defines from where to download GeoIP data and how frequently to update the data.
@@ -43,7 +43,7 @@ OpenSearch provides the following endpoints for GeoLite2 City, GeoLite2 Country,
 
 If an OpenSearch cluster cannot update a data source from the endpoints within 30 days, the cluster does not add GeoIP data to the documents and instead adds `"error":"ip2geo_data_expired"`.
 
-### Data source options
+#### Data source options
 
 The following table lists the data source options for the `ip2geo` processor.   
 
@@ -65,7 +65,7 @@ PUT /_plugins/geospatial/ip2geo/datasource/my-datasource
 
 A `true` response means that the request was successful and that the server was able to process the request. A `false` response indicates that you should check the request to make sure it is valid, check the URL to make sure it is correct, or try again.
 
-### Sending a GET request
+#### Sending a GET request
 
 To get information about one or more IP2Geo data sources, send a GET request:  
 
@@ -112,7 +112,7 @@ You'll receive the following response:
 }
 ```
 
-### Updating an IP2Geo data source
+#### Updating an IP2Geo data source
 
 See the Creating the IP2Geo data source section for a list of endpoints and request field descriptions. 
 
@@ -127,7 +127,7 @@ PUT /_plugins/geospatial/ip2geo/datasource/my-datasource/_settings
 ```
 {% include copy-curl.html %}
 
-### Deleting the IP2Geo data source
+#### Deleting the IP2Geo data source
 
 To delete the IP2Geo data source, you must first delete all processors associated with the data source. Otherwise, the request fails. 
 
@@ -152,7 +152,7 @@ Once the data source is created, you can create the pipeline. The following is t
 ```
 {% include copy-curl.html %}
 
-### Configuration parameters
+#### Configuration parameters
 
 The following table lists the required and optional parameters for the `ip2geo` processor.
 

--- a/_api-reference/ingest-apis/processors/lowercase.md
+++ b/_api-reference/ingest-apis/processors/lowercase.md
@@ -7,6 +7,8 @@ nav_order: 210
 ---
 
 # Lowercase
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `lowercase` processor converts all the text in a specific field to lowercase letters. The following is the syntax for the `lowercase` processor: 
 

--- a/_api-reference/ingest-apis/processors/remove.md
+++ b/_api-reference/ingest-apis/processors/remove.md
@@ -7,6 +7,8 @@ nav_order: 230
 ---
 
 # Remove
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `remove` processor is used to remove a field from a document. The following is the syntax for the `remove` processor: 
 

--- a/_api-reference/ingest-apis/processors/uppercase.md
+++ b/_api-reference/ingest-apis/processors/uppercase.md
@@ -7,6 +7,8 @@ nav_order: 310
 ---
 
 # Uppercase
+**Introduced 1.0**
+{: .label .label-purple }
 
 The `uppercase` processor converts all the text in a specific field to uppercase letters. The following is the syntax for the `uppercase` processor: 
 

--- a/_api-reference/ingest-apis/simulate-ingest.md
+++ b/_api-reference/ingest-apis/simulate-ingest.md
@@ -9,6 +9,8 @@ redirect_from:
 ---
 
 # Simulate pipeline
+**Introduced 1.0**
+{: .label .label-purple }
 
 Use the simulate ingest pipeline API operation to run or test the pipeline.
 
@@ -121,7 +123,7 @@ The request returns the following response:
 }
 ```
 
-### Example: Verbose mode
+#### Example: Verbose mode
 
 When the previous request is run with the `verbose` parameter set to `true`, the response shows the sequence of transformations for each document. For example, for the document with the ID `1`, the response contains the results of applying each processor in the pipeline in sequence:
 
@@ -189,7 +191,7 @@ When the previous request is run with the `verbose` parameter set to `true`, the
 }
 ```
 
-### Example: Specify a pipeline in the request body
+#### Example: Specify a pipeline in the request body
 
 Alternatively, you can specify a pipeline directly in the request body without first creating a pipeline:
 

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -7,13 +7,12 @@ redirect_from:
 ---
 
 # Multi-search
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 As the name suggests, the multi-search operation lets you bundle multiple search requests into a single request. OpenSearch then executes the searches in parallel, so you get back the response more quickly compared to sending one request per search. OpenSearch executes each search independently, so the failure of one doesn't affect the others.
 
-
-## Example
+**Example**
 
 ```json
 GET _msearch

--- a/_api-reference/nodes-apis/index.md
+++ b/_api-reference/nodes-apis/index.md
@@ -6,6 +6,8 @@ nav_order: 50
 ---
 
 # Nodes API
+**Introduced 1.0**
+{: .label .label-purple }
 
 The nodes API makes it possible to retrieve information about individual nodes within your cluster. 
 
@@ -59,7 +61,7 @@ GET /_nodes/data:true/stats
 ```
 {% include copy-curl.html %}
 
-### Order of resolution mechanisms
+#### Order of resolution mechanisms
 
 The order of resolution mechanisms is applied sequentially, and each can add or remove nodes. The following examples yield different results.
 

--- a/_api-reference/nodes-apis/nodes-hot-threads.md
+++ b/_api-reference/nodes-apis/nodes-hot-threads.md
@@ -6,10 +6,12 @@ nav_order: 30
 ---
 
 # Nodes hot threads
+**Introduced 1.0**
+{: .label .label-purple }
 
 The nodes hot threads endpoint provides information about busy JVM threads for selected cluster nodes. It provides a unique view of the of activity each node.
 
-## Example
+**Example**
 
 ```json
 GET /_nodes/hot_threads

--- a/_api-reference/nodes-apis/nodes-info.md
+++ b/_api-reference/nodes-apis/nodes-info.md
@@ -6,6 +6,8 @@ nav_order: 10
 ---
 
 # Nodes info
+**Introduced 1.0**
+{: .label .label-purple }
 
 The nodes info API represents mostly static information about your cluster's nodes, including but not limited to:
 
@@ -16,7 +18,7 @@ The nodes info API represents mostly static information about your cluster's nod
 - Thread pools settings 
 - Installed plugins
 
-## Example
+**Example**
 
 To get information about all nodes in a cluster, use the following query:
 

--- a/_api-reference/nodes-apis/nodes-reload-secure.md
+++ b/_api-reference/nodes-apis/nodes-reload-secure.md
@@ -6,6 +6,8 @@ nav_order: 50
 ---
 
 # Nodes reload secure settings
+**Introduced 1.0**
+{: .label .label-purple }
 
 The nodes reload secure settings endpoint allows you to change secure settings on a node and reload the secure settings without restarting the node.
 

--- a/_api-reference/nodes-apis/nodes-stats.md
+++ b/_api-reference/nodes-apis/nodes-stats.md
@@ -6,6 +6,8 @@ nav_order: 20
 ---
 
 # Nodes stats
+**Introduced 1.0**
+{: .label .label-purple }
 
 The nodes stats API returns statistics about your cluster.
 

--- a/_api-reference/nodes-apis/nodes-usage.md
+++ b/_api-reference/nodes-apis/nodes-usage.md
@@ -6,6 +6,8 @@ nav_order: 40
 ---
 
 # Nodes usage
+**Introduced 1.0**
+{: .label .label-purple }
 
 The nodes usage endpoint returns low-level information about REST action usage on nodes.
 

--- a/_api-reference/popular-api.md
+++ b/_api-reference/popular-api.md
@@ -7,6 +7,8 @@ redirect_from:
 ---
 
 # Popular APIs
+**Introduced 1.0**
+{: .label .label-purple }
 
 This page contains example requests for popular OpenSearch operations.
 

--- a/_api-reference/profile.md
+++ b/_api-reference/profile.md
@@ -5,6 +5,8 @@ nav_order: 55
 ---
 
 # Profile
+**Introduced 1.0**
+{: .label .label-purple }
 
 The Profile API provides timing information about the execution of individual components of a search request. Using the Profile API, you can debug slow requests and understand how to improve their performance. The Profile API does not measure the following:
 

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -5,6 +5,8 @@ nav_order: 60
 ---
 
 # Ranking evaluation
+**Introduced 1.0**
+{: .label .label-purple }
 
 The [rank]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/rank/) eval endpoint allows you to evaluate the quality of ranked search results.
 

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 # Remote cluster information
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 This operation provides connection information for any remote OpenSearch clusters that you've configured for the local cluster, such as the remote cluster alias, connection mode (`sniff` or `proxy`), IP addresses for seed nodes, and timeout settings.

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -5,7 +5,9 @@ parent: Script APIs
 nav_order: 1
 ---
 
-## Create or update stored script
+# Create or update stored script
+**Introduced 1.0**
+{: .label .label-purple }
 
 Creates or updates a stored script or search template.
 
@@ -16,13 +18,13 @@ For additional information about Painless scripting, see:
 * [k-NN]({{site.url}}{{site.baseurl}}/search-plugins/knn/index/).
 
 
-### Path parameters
+## Path parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
 | script-id | String | Stored script or search template ID. Must be unique across the cluster. Required. |
 
-### Query parameters
+## Query parameters
 
 All parameters are optional.
 
@@ -32,7 +34,7 @@ All parameters are optional.
 | cluster_manager_timeout | Time | Amount of time to wait for a connection to the cluster manager. Defaults to 30 seconds. |
 | timeout | Time | The period of time to wait for a response. If a response is not received before the timeout value, the request fails and returns an error. Defaults to 30 seconds.|
 
-### Request fields
+## Request fields
 
 | Field | Data type | Description | 
 :--- | :--- | :---
@@ -138,7 +140,7 @@ To determine whether the script was successfully created, use the [Get stored sc
 
 The Painless script supports `params` to pass variables to the script. 
 
-### Example
+#### Example
 
 The following request creates the Painless script `multiplier-script`. The request sums the ratings for each book, multiplies the summed value by the `multiplier` parameter, and displays the result in the output:
 

--- a/_api-reference/script-apis/delete-script.md
+++ b/_api-reference/script-apis/delete-script.md
@@ -5,11 +5,13 @@ parent: Script APIs
 nav_order: 4
 ---
 
-## Delete script
+# Delete script
+**Introduced 1.0**
+{: .label .label-purple }
 
 Deletes a stored script
 
-### Path parameters
+## Path parameters
 
 Path parameters are optional. 
 
@@ -17,7 +19,7 @@ Path parameters are optional.
 :--- | :--- | :---
 | script-id | String | ID of script to delete. |
 
-### Query parameters
+## Query parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
@@ -45,7 +47,7 @@ The `DELETE _scripts/my-first-script` request returns the following field:
 
 To determine whether the stored script was successfully deleted, use the [Get stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/get-stored-script/) API, passing the script name as the `script` path parameter.
 
-### Response fields
+## Response fields
 
 The <HTTP METHOD> <endpoint> request returns the following response fields:
 

--- a/_api-reference/script-apis/exec-script.md
+++ b/_api-reference/script-apis/exec-script.md
@@ -5,18 +5,20 @@ parent: Script APIs
 nav_order: 7
 ---
 
-## Execute Painless script
+# Execute Painless script
+**Introduced 1.0**
+{: .label .label-purple }
 
 The Execute Painless script API allows you to run a script that is not stored.
 
-### Path and HTTP methods
+## Path and HTTP methods
 
 ```json
 GET /_scripts/painless/_execute
 POST /_scripts/painless/_execute
 ```
 
-### Request fields
+## Request fields
 
 | Field | Description | 
 :--- | :---
@@ -52,7 +54,7 @@ The response contains the average of two script parameters:
 }
 ```
 
-### Response fields
+## Response fields
 
 | Field | Description | 
 :--- | :--- 
@@ -63,11 +65,11 @@ The response contains the average of two script parameters:
 
 Choose different contexts to control the variables that are available to the script and the result's return type. The default context is `painless_test`.
 
-### Painless test context
+## Painless test context
 
 The `painless_test` context is the default script context that provides only the `params` variable to the script. The returned result is always converted to a string. See the preceding example request for a usage example.
 
-### Filter context
+## Filter context
 
 The `filter` context runs the script as if the script were inside a script query. You must provide a test document in the context. The `_source`, stored fields, and `_doc` variables will be available to the script.
 
@@ -128,7 +130,7 @@ The response contains the result:
 }
 ```
 
-### Score context
+## Score context
 
 The `score` context runs a script as if the script were in a `script_score` function in a `function_score` query.
 

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -5,13 +5,15 @@ parent: Script APIs
 nav_order: 2
 ---
 
-## Execute Painless stored script
+# Execute Painless stored script
+**Introduced 1.0**
+{: .label .label-purple }
 
 Runs a stored script written in the Painless language. 
 
 OpenSearch provides several ways to run a script; the following sections show how to run a script by passing script information in the request body of a `GET <index>/_search` request.
 
-### Request fields
+## Request fields
 
 | Field | Data type | Description | 
 :--- | :--- | :---
@@ -102,7 +104,7 @@ The `GET books/_search` request returns the following fields:
 }
 ````
 
-### Response fields
+## Response fields
 
 | Field | Data type | Description | 
 :--- | :--- | :---
@@ -132,7 +134,7 @@ The `GET books/_search` request returns the following fields:
 
 To pass different parameters to the script each time when running a query, define `params` in `script_fields`.
 
-### Example
+#### Example
 
 The following request runs the stored script that was created in [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/). The script sums the ratings for each book, multiplies the summed value by the `multiplier` parameter, and displays the result in the output.
 
@@ -164,7 +166,7 @@ GET books/_search
 ````
 {% include copy-curl.html %}
 
-### Example response
+#### Example response
 ````json
 {
   "took" : 12,
@@ -220,10 +222,10 @@ GET books/_search
 }
 ```
 
-## Sort results using painless stored script
-You can use painless stored script to sort results.
+**Sort results using painless stored script
+You can use painless stored script to sort results.**
 
-### Sample request
+#### Sample request
 
 ````json
 GET books/_search
@@ -256,7 +258,7 @@ GET books/_search
 }
 ```
 
-### Sample response
+#### Sample response
 
 ````json
 {

--- a/_api-reference/script-apis/get-script-contexts.md
+++ b/_api-reference/script-apis/get-script-contexts.md
@@ -5,7 +5,9 @@ parent: Script APIs
 nav_order: 5
 ---
 
-## Get stored script contexts
+# Get stored script contexts
+**Introduced 1.0**
+{: .label .label-purple }
 
 Retrieves all contexts for stored scripts.
 
@@ -545,7 +547,7 @@ The `GET _script_context` request returns the following fields:
 }
 ````
 
-### Response fields
+## Response fields
 
 The `GET _script_context` request returns the following response fields:
 

--- a/_api-reference/script-apis/get-script-language.md
+++ b/_api-reference/script-apis/get-script-language.md
@@ -5,7 +5,9 @@ parent: Script APIs
 nav_order: 6
 ---
 
-## Get script language
+# Get script language
+**Introduced 1.0**
+{: .label .label-purple }
 
 The get script language API operation retrieves all supported script languages and their contexts.
 
@@ -87,7 +89,7 @@ The `GET _script_language` request returns the available contexts for each langu
 }
 ```
 
-### Response fields
+## Response fields
 
 The request contains the following response fields.
 

--- a/_api-reference/script-apis/get-stored-script.md
+++ b/_api-reference/script-apis/get-stored-script.md
@@ -5,17 +5,19 @@ parent: Script APIs
 nav_order: 3
 ---
 
-## Get stored script
+# Get stored script
+**Introduced 1.0**
+{: .label .label-purple }
 
 Retrieves a stored script.
 
-### Path parameters
+## Path parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
 | script | String | Stored script or search template name. Required.|
 
-### Query parameters
+## Query parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
@@ -51,7 +53,7 @@ The `GET _scripts/my-first-script` request returns the following fields:
 }
 ````
 
-### Response fields
+## Response fields
 
 The `GET _scripts/my-first-script` request returns the following response fields:
 

--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -8,5 +8,7 @@ redirect_from:
 ---
 
 # Script APIs
+**Introduced 1.0**
+{: .label .label-purple }
 
 The script APIs allow you to work with stored scripts. Stored scripts are part of the cluster state and reduce compilation time and enhance search speed. The default scripting language is Painless.

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 # Scroll
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 You can use the `scroll` operation to retrieve a large number of results. For example, for machine learning jobs, you can request an unlimited number of results in batches.
@@ -17,7 +17,7 @@ To use the `scroll` operation, add a `scroll` parameter to the request header wi
 Because search contexts consume a lot of memory, we suggest you don't use the `scroll` operation for frequent user queries. Instead, use the `sort` parameter with the `search_after` parameter to scroll responses for user queries.
 {: .note }
 
-## Example
+**Example**
 
 To set the number of results that you want returned for each batch, use the `size` parameter:
 

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -7,12 +7,12 @@ redirect_from:
 ---
 
 # Search
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 The Search API operation lets you execute a search request to search your cluster for data.
 
-## Example
+**Example**
 
 ```json
 GET /movies/_search

--- a/_api-reference/snapshots/create-repository.md
+++ b/_api-reference/snapshots/create-repository.md
@@ -6,6 +6,8 @@ nav_order: 1
 ---
 
 # Registering or updating a snapshot repository
+**Introduced 1.0**
+{: .label .label-purple }
 
 You can register a new repository in which to store snapshots or update information for an existing repository by using the snapshots API.
 
@@ -34,7 +36,7 @@ repository | String | Repository name |
 
 Request parameters depend on the type of repository: `fs` or `s3`.
 
-### fs repository
+#### fs repository
 
 Request field | Description
 :--- | :---
@@ -61,7 +63,7 @@ PUT /_snapshot/my-fs-repository
 ```
 {% include copy-curl.html %}
 
-### s3 repository
+#### s3 repository
 
 Request field | Description
 :--- | :---

--- a/_api-reference/snapshots/create-snapshot.md
+++ b/_api-reference/snapshots/create-snapshot.md
@@ -5,7 +5,9 @@ parent: Snapshot APIs
 nav_order: 5
 ---
 
-## Create snapshot
+# Create snapshot
+**Introduced 1.0**
+{: .label .label-purple }
 
 Creates a snapshot within an existing repository.
 
@@ -13,27 +15,27 @@ Creates a snapshot within an existing repository.
 
 * To view a list of your repositories, see [Get snapshot repository]({{site.url}}{{site.baseurl}}/api-reference/snapshots/get-snapshot-repository).
 
-### Path and HTTP methods
+## Path and HTTP methods
 
 ```json
 PUT /_snapshot/<repository>/<snapshot>
 POST /_snapshot/<repository>/<snapshot>
 ```
 
-### Path parameters
+## Path parameters
 
 Parameter | Data type | Description
 :--- | :--- | :---
 repository | String | Repostory name to contain the snapshot. |
 snapshot | String | Name of Snapshot to create. |
 
-### Query parameters
+## Query parameters
 
 Parameter | Data type | Description
 :--- | :--- | :---
 wait_for_completion | Boolean |  Whether to wait for snapshot creation to complete before continuing. If you include this parameter, the snapshot definition is returned after completion. |
 
-### Request fields
+## Request fields
 
 The request body is optional.
 

--- a/_api-reference/snapshots/delete-snapshot-repository.md
+++ b/_api-reference/snapshots/delete-snapshot-repository.md
@@ -5,7 +5,9 @@ parent: Snapshot APIs
 nav_order: 3
 ---
 
-## Delete snapshot repository configuration
+# Delete snapshot repository configuration
+**Introduced 1.0**
+{: .label .label-purple }
 
  Deletes a snapshot repository configuration.  
  
@@ -13,7 +15,7 @@ nav_order: 3
 
  To learn more about repositories, see [Register or update snapshot repository]({{site.url}}{{site.baseurl}}/api-reference/snapshots/create-repository).
 
-### Path parameters
+## Path parameters
 
 Parameter | Data type | Description
 :--- | :--- | :---

--- a/_api-reference/snapshots/delete-snapshot.md
+++ b/_api-reference/snapshots/delete-snapshot.md
@@ -6,6 +6,8 @@ nav_order: 7
 ---
 
 ## Delete snapshot
+**Introduced 1.0**
+{: .label .label-purple }
 
 Deletes a snapshot from a repository.
 
@@ -15,7 +17,7 @@ Deletes a snapshot from a repository.
 
 * To view a list of your snapshots, see [cat snapshots]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-snapshots).
 
-### Path parameters
+## Path parameters
 
 Parameter | Data type | Description
 :--- | :--- | :---

--- a/_api-reference/snapshots/get-snapshot-repository.md
+++ b/_api-reference/snapshots/get-snapshot-repository.md
@@ -5,7 +5,9 @@ parent: Snapshot APIs
 nav_order: 2
 ---
 
-## Get snapshot repository.
+# Get snapshot repository.
+**Introduced 1.0**
+{: .label .label-purple }
 
 Retrieves information about a snapshot repository.
 
@@ -14,13 +16,13 @@ To learn more about repositories, see [Register repository]({{site.url}}{{site.b
 You can also get details about a snapshot during and after snapshot creation. See [Get snapshot status]({{site.url}}{{site.baseurl}}/api-reference/snapshots/get-snapshot-status/).
 {: .note}
 
-### Path parameters
+## Path parameters
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
 | repository | String | A comma-separated list of snapshot repository names to retrieve. Wildcard (`*`) expressions are supported including combining wildcards with exclude patterns starting with `-`. |
 
-### Query parameters
+## Query parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
@@ -52,7 +54,7 @@ Upon success, the response returns repositry information. This sample is for an 
 }
 ````
 
-### Response fields
+## Response fields
 
 | Field | Data type | Description |
 | :--- | :--- | :--- | 

--- a/_api-reference/snapshots/get-snapshot-status.md
+++ b/_api-reference/snapshots/get-snapshot-status.md
@@ -5,7 +5,9 @@ parent: Snapshot APIs
 nav_order: 8
 ---
 
-## Get snapshot status
+# Get snapshot status
+**Introduced 1.0**
+{: .label .label-purple }
 
 Returns details about a snapshot’s state during and after snapshot creation.
 
@@ -14,7 +16,7 @@ To learn about snapshot creation, see [Create snapshot]({{site.url}}{{site.baseu
 If you use the Security plugin, you must have the `monitor_snapshot`, `create_snapshot`, or `manage cluster` privileges.
 {: .note}
 
-### Path parameters
+## Path parameters
 
 Path parameters are optional. 
 
@@ -34,7 +36,7 @@ Three request variants provide flexibility:
 Using the API to return state for other than currently running snapshots can be very costly for (1) machine machine resources and (2) processing time if running in the cloud. For each snapshot, each request causes file reads from all a snapshot's shards. 
 {: .warning}
 
-### Request fields
+## Request fields
 
 | Field | Data type | Description | 
 :--- | :--- | :---
@@ -367,7 +369,7 @@ The `GET _snapshot/my-opensearch-repo/my-first-snapshot/_status` request returns
 }
 ````
 
-### Response fields
+## Response fields
 
 | Field | Data type | Description | 
 :--- | :--- | :---

--- a/_api-reference/snapshots/get-snapshot.md
+++ b/_api-reference/snapshots/get-snapshot.md
@@ -5,18 +5,20 @@ parent: Snapshot APIs
 nav_order: 6
 ---
 
-## Get snapshot.
+# Get snapshot.
+**Introduced 1.0**
+{: .label .label-purple }
 
 Retrieves information about a snapshot.
 
-### Path parameters
+## Path parameters
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
 | repository | String | The repository that contains the snapshot to retrieve. |
 | snapshot | String | Snapshot to retrieve.
 
-### Query parameters
+## Query parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
@@ -71,7 +73,7 @@ Upon success, the response returns snapshot information:
   ]
 }
 ````
-### Response fields
+## Response fields
 
 | Field | Data type | Description |
 | :--- | :--- | :--- | 

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -9,5 +9,7 @@ redirect_from:
 ---
 
 # Snapshot APIs
+**Introduced 1.0**
+{: .label .label-purple }
 
 The snapshot APIs allow you to manage snapshots and snapshot repositories.

--- a/_api-reference/snapshots/restore-snapshot.md
+++ b/_api-reference/snapshots/restore-snapshot.md
@@ -6,7 +6,9 @@ parent: Snapshot APIs
 nav_order: 9
 ---
 
-## Restore Snapshot
+# Restore Snapshot
+**Introduced 1.0**
+{: .label .label-purple }
 
 Restores a snapshot of a cluster or specified data streams and indices. 
 
@@ -17,14 +19,14 @@ Restores a snapshot of a cluster or specified data streams and indices.
 If open indexes with the same name that you want to restore already exist in the cluster, you must close, delete, or rename the indexes. See [Example request](#example-request) for information about renaming an index. See [Close index]({{site.url}}{{site.baseurl}}/api-reference/index-apis/close-index) for information about closing an index.
 {: .note}
 
-### Path parameters
+## Path parameters
 
 | Parameter | Data type | Description |
 :--- | :--- | :---
 repository | String | Repository containing the snapshot to restore. |
 | snapshot | String | Snapshot to restore. |
 
-### Query parameters
+## Query parameters
 
 Parameter | Data type | Description
 :--- | :--- | :---
@@ -90,7 +92,7 @@ Upon success, the response returns the following JSON object:
 ````
 Except for the snapshot name, all properties are empty or `0`. This is because any changes made to the volume after the snapshot was generated are lost. However, if you invoke the [Get snapshot]({{site.url}}{{site.baseurl}}/api-reference/snapshots/get-snapshot) API to examine the snapshot, a fully populated snapshot object is returned. 
 
-### Response fields
+## Response fields
 
 | Field | Data type | Description |
 | :--- | :--- | :--- | 

--- a/_api-reference/snapshots/verify-snapshot-repository.md
+++ b/_api-reference/snapshots/verify-snapshot-repository.md
@@ -6,7 +6,9 @@ parent: Snapshot APIs
 nav_order: 4
 ---
 
-## Verify snapshot repository
+# Verify snapshot repository
+**Introduced 1.0**
+{: .label .label-purple }
 
 Verifies that a snapshot repository is functional. Verifies the repository on each node in a cluster.
 
@@ -15,7 +17,7 @@ If verification is successful, the verify snapshot repository API returns a list
 If you use the Security plugin, you must have the `manage cluster` privilege.
 {: .note}
 
-### Path parameters
+## Path parameters
 
 Path parameters are optional. 
 
@@ -23,7 +25,7 @@ Path parameters are optional.
 :--- | :--- | :---
 | repository | String | Name of repository to verify. |
 
-### Query parameters
+## Query parameters
 
 | Parameter | Data type | Description | 
 :--- | :--- | :---
@@ -68,7 +70,7 @@ In the preceding sample, one node is connected to the snapshot repository. If mo
 }
 ````
 
-### Response fields
+## Response fields
 
 | Field | Data type | Description | 
 :--- | :--- | :---

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 # Tasks
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 A task is any operation you run in a cluster. For example, searching your data collection of books for a title or author name is a task. When you run OpenSearch, a task is automatically created to monitor your cluster's health and performance. For more information about all of the tasks currently executing in your cluster, you can use the `tasks` API operation.

--- a/_api-reference/units.md
+++ b/_api-reference/units.md
@@ -7,6 +7,8 @@ redirect_from:
 ---
 
 # Supported units
+**Introduced 1.0**
+{: .label .label-purple }
 
 OpenSearch supports the following units for all REST operations:
 


### PR DESCRIPTION
### Description
 Fix API reference section according to API template.
- Reordering the sections so that they are in the correct order.
- Ensuring all field names and variables are in code font (surrounded by tick marks (`)).
- Ensuring the headings are heading level 2 for the section names and level 4 for examples.
- Make heading levels consistent across pages.
- Make sure API names use the same capitalization.
- Make sure that each page uses terminology that matches the template.

### Issues Resolved
Closes Issue #4689


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
